### PR TITLE
Remove unused communication channels

### DIFF
--- a/docs/community/communication.md
+++ b/docs/community/communication.md
@@ -4,25 +4,15 @@ There are different ways and channels that you can use as a community member or 
 meet fellow _Anovos_ users, and collaborate on improving the library.
 
 ## 💬 Slack
-The _Anovos_ community has a channel on the [Feature Engineers Slack Workspace](https://featureengineers.slack.com/join/shared_invite/zt-17pkc3f5d-33SUtV8Wx48CpiIRNuQ7JA#/shared-invite/email) called `#anovos`.
-Feel free to join us there! 
+
+The _Anovos_ community has a channel on the
+[Feature Engineers Slack Workspace](https://featureengineers.slack.com/join/shared_invite/zt-17pkc3f5d-33SUtV8Wx48CpiIRNuQ7JA#/shared-invite/email)
+called `#anovos`.
+Feel free to join us there!
 It's the perfect place get in touch with the community as well as the maintainers of _Anovos_.
 
 ## 🚧 GitHub Issues
-If you encounter a bug or have a feature request, please  [file an issue on GitHub](https://github.com/anovos/anovos/issues).
+
+If you encounter a bug or have a feature request, please
+[file an issue on GitHub](https://github.com/anovos/anovos/issues).
 We'll make sure to get back to you in time.
-
-## ✉ Contributor Mailing List
-If you want to follow discussions about the development of _Anovos_ and perhaps would like to become a contributor,
-please sign up for our [Mailing List](https://groups.google.com/g/anovos-contributors).
-
-Don't worry: On the list, the focus is 100% on ongoing and future development, you won't be spammed with general questions
-or support requests.
-
-## 👥 Monthly Contributor Meeting
-
-We have a monthly meeting to sync ongoing work and discuss feature requests.
-You will automatically receive an invitation when joining the contributor mailing list.
-
-For each meeting, an agenda is shared ahead of time via Google Docs.
-Feel free to add any items you would like to discuss.


### PR DESCRIPTION
Doesn't seem like the mailing list is used and as far as I know no contributor meetings have been taking place over the past year?